### PR TITLE
feat: add initial core structure

### DIFF
--- a/src/main/java/com/si516/saludconecta/config/Example.java
+++ b/src/main/java/com/si516/saludconecta/config/Example.java
@@ -1,0 +1,4 @@
+package com.si516.saludconecta.config;
+
+public class Example {
+}

--- a/src/main/java/com/si516/saludconecta/controller/Example.java
+++ b/src/main/java/com/si516/saludconecta/controller/Example.java
@@ -1,0 +1,4 @@
+package com.si516.saludconecta.controller;
+
+public class Example {
+}

--- a/src/main/java/com/si516/saludconecta/document/Example.java
+++ b/src/main/java/com/si516/saludconecta/document/Example.java
@@ -1,0 +1,4 @@
+package com.si516.saludconecta.document;
+
+public class Example {
+}

--- a/src/main/java/com/si516/saludconecta/repository/Example.java
+++ b/src/main/java/com/si516/saludconecta/repository/Example.java
@@ -1,0 +1,4 @@
+package com.si516.saludconecta.repository;
+
+public class Example {
+}

--- a/src/main/java/com/si516/saludconecta/service/Example.java
+++ b/src/main/java/com/si516/saludconecta/service/Example.java
@@ -1,0 +1,4 @@
+package com.si516.saludconecta.service;
+
+public interface Example {
+}

--- a/src/main/java/com/si516/saludconecta/service/impl/ExampleImpl.java
+++ b/src/main/java/com/si516/saludconecta/service/impl/ExampleImpl.java
@@ -1,0 +1,4 @@
+package com.si516.saludconecta.service.impl;
+
+public class ExampleImpl {
+}


### PR DESCRIPTION
This pull request introduces new placeholder classes and interfaces across various packages in the project structure, likely as part of initial scaffolding for future development. Each file defines an empty class or interface within its respective package.

### New scaffolding for project structure:

* [`src/main/java/com/si516/saludconecta/config/Example.java`](diffhunk://#diff-e028302195e08d34af0d4ba4e3a5511af70bb50c5a495f6ffc4257c3e39d5d44R1-R4): Added an empty `Example` class in the `config` package.
* [`src/main/java/com/si516/saludconecta/controller/Example.java`](diffhunk://#diff-ad1e278147e59b20f5b5d28fb5bfb15b0babc80b9ee9214ec8d836700eaca8f7R1-R4): Added an empty `Example` class in the `controller` package.
* [`src/main/java/com/si516/saludconecta/document/Example.java`](diffhunk://#diff-3fd21c341d4dd85ad199b60d102701a0c57ecb61f5220b29aa4533ac86a973ffR1-R4): Added an empty `Example` class in the `document` package.
* [`src/main/java/com/si516/saludconecta/repository/Example.java`](diffhunk://#diff-b182f2fdc94db3a175a8b22fdb866475741010ddc2ddec5548723888c1236df9R1-R4): Added an empty `Example` class in the `repository` package.
* [`src/main/java/com/si516/saludconecta/service/Example.java`](diffhunk://#diff-92cbc4084cef9aed8848cb2261450df99172743fe95c0f2ec4fd90133afe87bcR1-R4): Added an empty `Example` interface in the `service` package.
* [`src/main/java/com/si516/saludconecta/service/impl/ExampleImpl.java`](diffhunk://#diff-3ee9f6bdd396b8bfcc03180f13615066e6ed791b0a73b118f6c1743c41d307ddR1-R4): Added an empty `ExampleImpl` class in the `service.impl` package.

### Related issue
* Closes #2 