### PR TITLE
feat: add initial repositories for documents

### DIFF
--- a/src/main/java/com/si516/saludconecta/repository/ClinicHistoryRepository.java
+++ b/src/main/java/com/si516/saludconecta/repository/ClinicHistoryRepository.java
@@ -1,0 +1,6 @@
+package com.si516.saludconecta.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface ClinicHistoryRepository extends MongoRepository<ClinicHistoryRepository, String> {
+}

--- a/src/main/java/com/si516/saludconecta/repository/DoctorRepository.java
+++ b/src/main/java/com/si516/saludconecta/repository/DoctorRepository.java
@@ -1,0 +1,6 @@
+package com.si516.saludconecta.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface DoctorRepository extends MongoRepository<DoctorRepository, String> {
+}

--- a/src/main/java/com/si516/saludconecta/repository/OfficeRepository.java
+++ b/src/main/java/com/si516/saludconecta/repository/OfficeRepository.java
@@ -1,0 +1,7 @@
+package com.si516.saludconecta.repository;
+
+import com.si516.saludconecta.document.Office;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface OfficeRepository extends MongoRepository<Office, String> {
+}

--- a/src/main/java/com/si516/saludconecta/repository/PatientRepository.java
+++ b/src/main/java/com/si516/saludconecta/repository/PatientRepository.java
@@ -1,0 +1,7 @@
+package com.si516.saludconecta.repository;
+
+import com.si516.saludconecta.document.Patient;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface PatientRepository extends MongoRepository<Patient, String> {
+}


### PR DESCRIPTION
This pull request introduces new repository interfaces for MongoDB integration in the `com.si516.saludconecta.repository` package. These changes enable CRUD operations for various entities in the application.

### Repository Interfaces Added:

* **`ClinicHistoryRepository`**: A new repository interface extending `MongoRepository` to handle `ClinicHistoryRepository` entities.
* **`DoctorRepository`**: A new repository interface extending `MongoRepository` to manage `DoctorRepository` entities.
* **`OfficeRepository`**: A new repository interface extending `MongoRepository` for `Office` entities.
* **`PatientRepository`**: A new repository interface extending `MongoRepository` for `Patient` entities.

### Related issues:
* Closes: #5 