### PR TITLE
refactor: enhance Clinic History schema

### DIFF
--- a/src/main/java/com/si516/saludconecta/document/ClinicHistory.java
+++ b/src/main/java/com/si516/saludconecta/document/ClinicHistory.java
@@ -3,6 +3,7 @@ package com.si516.saludconecta.document;
 import java.time.Instant;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -24,6 +25,9 @@ public class ClinicHistory {
     private List<String> symptoms;
     private List<Treatment> treatment;      // clase embebida
     private Pickup pickup;      // clase embebida
+    @JsonFormat(shape = JsonFormat.Shape.STRING,
+            pattern = "dd-MM-yyyy HH:mm:ss",
+            timezone = "America/La_Paz")
     private Instant createdAt;
     // getters/setters, constructores
 }

--- a/src/main/java/com/si516/saludconecta/document/ClinicHistory.java
+++ b/src/main/java/com/si516/saludconecta/document/ClinicHistory.java
@@ -25,9 +25,6 @@ public class ClinicHistory {
     private List<String> symptoms;
     private List<Treatment> treatment;      // clase embebida
     private Pickup pickup;      // clase embebida
-    @JsonFormat(shape = JsonFormat.Shape.STRING,
-            pattern = "dd-MM-yyyy HH:mm:ss",
-            timezone = "America/La_Paz")
     private Instant createdAt;
     // getters/setters, constructores
 }

--- a/src/main/java/com/si516/saludconecta/document/ClinicHistory.java
+++ b/src/main/java/com/si516/saludconecta/document/ClinicHistory.java
@@ -23,7 +23,7 @@ public class ClinicHistory {
     private String diagnosis;
     private List<String> symptoms;
     private List<Treatment> treatment;      // clase embebida
-    private Prescription prescription;      // clase embebida
+    private Pickup pickup;      // clase embebida
     private Instant createdAt;
     // getters/setters, constructores
 }

--- a/src/main/java/com/si516/saludconecta/document/ClinicHistory.java
+++ b/src/main/java/com/si516/saludconecta/document/ClinicHistory.java
@@ -18,7 +18,6 @@ public class ClinicHistory {
     @Id
     private String id;
     private String doctorId;
-    private String officeId;
     private String patientId;
     private String visitReason;
     private String diagnosis;

--- a/src/main/java/com/si516/saludconecta/document/Pickup.java
+++ b/src/main/java/com/si516/saludconecta/document/Pickup.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class Prescription {
+public class Pickup {
     private PickupType pickupType;   // NOW, SCHEDULED o LATER
     private String scheduledTime;    // formato "HH:mm" o null si no aplica
 }

--- a/src/main/java/com/si516/saludconecta/dto/ClinicHistoryDTO.java
+++ b/src/main/java/com/si516/saludconecta/dto/ClinicHistoryDTO.java
@@ -14,7 +14,6 @@ import java.util.List;
 public record ClinicHistoryDTO(
         @Null(message = "Id must be null when creating") String id,
         @NotNull(message = "Doctor ID must not be null when creating") String doctorId,
-        @NotNull(message = "Office ID must not be null when creating") String officeId,
         @NotNull(message = "Patient ID must not be null when creating") String patientId,
         @NotBlank(message = "Visit reason is required") String visitReason,
         @NotBlank(message = "Diagnosis is required") String diagnosis,

--- a/src/main/java/com/si516/saludconecta/dto/ClinicHistoryDTO.java
+++ b/src/main/java/com/si516/saludconecta/dto/ClinicHistoryDTO.java
@@ -1,5 +1,6 @@
 package com.si516.saludconecta.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.si516.saludconecta.document.Pickup;
 import com.si516.saludconecta.document.Treatment;
 import jakarta.validation.constraints.NotBlank;
@@ -7,6 +8,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Null;
 import jakarta.validation.constraints.Size;
 
+import java.time.Instant;
 import java.util.List;
 
 public record ClinicHistoryDTO(
@@ -18,7 +20,11 @@ public record ClinicHistoryDTO(
         @NotBlank(message = "Diagnosis is required") String diagnosis,
         @NotNull(message = "Symptoms must not be null") @Size(min = 1, message = "Symptoms must contain at least one item") List<String> symptoms,
         @NotNull(message = "Treatment must not be null") @Size(min = 1, message = "Treatment must contain at least one item") List<Treatment> treatment,
-        @NotNull(message = "Pickup is required") Pickup pickup
+        @NotNull(message = "Pickup is required") Pickup pickup,
+        @JsonFormat(shape = JsonFormat.Shape.STRING,
+                pattern = "dd-MM-yyyy HH:mm:ss",
+                timezone = "America/La_Paz")
+        @NotNull(message = "createdAt is required") Instant createdAt
 
 ) {
 }

--- a/src/main/java/com/si516/saludconecta/dto/ClinicHistoryDTO.java
+++ b/src/main/java/com/si516/saludconecta/dto/ClinicHistoryDTO.java
@@ -1,6 +1,6 @@
 package com.si516.saludconecta.dto;
 
-import com.si516.saludconecta.document.Prescription;
+import com.si516.saludconecta.document.Pickup;
 import com.si516.saludconecta.document.Treatment;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -9,16 +9,16 @@ import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
-public record ClinicHistoryDTO (
+public record ClinicHistoryDTO(
         @Null(message = "Id must be null when creating") String id,
         @NotNull(message = "Doctor ID must not be null when creating") String doctorId,
         @NotNull(message = "Office ID must not be null when creating") String officeId,
         @NotNull(message = "Patient ID must not be null when creating") String patientId,
         @NotBlank(message = "Visit reason is required") String visitReason,
         @NotBlank(message = "Diagnosis is required") String diagnosis,
-        @NotNull(message = "Symptoms must not be null") @Size(min=1, message = "Symptoms must contain at least one item") List<String> symptoms,
-        @NotNull(message = "Treatment must not be null") @Size(min=1, message = "Treatment must contain at least one item") List<Treatment> treatment,
-        @NotNull(message = "Prescription is required") Prescription prescription
+        @NotNull(message = "Symptoms must not be null") @Size(min = 1, message = "Symptoms must contain at least one item") List<String> symptoms,
+        @NotNull(message = "Treatment must not be null") @Size(min = 1, message = "Treatment must contain at least one item") List<Treatment> treatment,
+        @NotNull(message = "Pickup is required") Pickup pickup
 
 ) {
 }

--- a/src/main/java/com/si516/saludconecta/dto/ClinicHistoryDTO.java
+++ b/src/main/java/com/si516/saludconecta/dto/ClinicHistoryDTO.java
@@ -23,7 +23,7 @@ public record ClinicHistoryDTO(
         @JsonFormat(shape = JsonFormat.Shape.STRING,
                 pattern = "dd-MM-yyyy HH:mm:ss",
                 timezone = "America/La_Paz")
-        @NotNull(message = "createdAt is required") Instant createdAt
+        @Null(message = "createdAt must be null when creating") Instant createdAt
 
 ) {
 }

--- a/src/main/java/com/si516/saludconecta/mapper/ClinicHistoryMapper.java
+++ b/src/main/java/com/si516/saludconecta/mapper/ClinicHistoryMapper.java
@@ -8,7 +8,6 @@ public class ClinicHistoryMapper {
         return new ClinicHistory(
                 dto.id(),
                 dto.doctorId(),
-                dto.officeId(),
                 dto.patientId(),
                 dto.visitReason(),
                 dto.diagnosis(),
@@ -23,7 +22,6 @@ public class ClinicHistoryMapper {
         return new ClinicHistoryDTO(
                 clinicHistory.getId(),
                 clinicHistory.getDoctorId(),
-                clinicHistory.getOfficeId(),
                 clinicHistory.getPatientId(),
                 clinicHistory.getVisitReason(),
                 clinicHistory.getDiagnosis(),

--- a/src/main/java/com/si516/saludconecta/mapper/ClinicHistoryMapper.java
+++ b/src/main/java/com/si516/saludconecta/mapper/ClinicHistoryMapper.java
@@ -29,7 +29,8 @@ public class ClinicHistoryMapper {
                 clinicHistory.getDiagnosis(),
                 clinicHistory.getSymptoms(),
                 clinicHistory.getTreatment(),
-                clinicHistory.getPickup()
+                clinicHistory.getPickup(),
+                clinicHistory.getCreatedAt()
         );
     }
 }

--- a/src/main/java/com/si516/saludconecta/mapper/ClinicHistoryMapper.java
+++ b/src/main/java/com/si516/saludconecta/mapper/ClinicHistoryMapper.java
@@ -14,7 +14,7 @@ public class ClinicHistoryMapper {
                 dto.diagnosis(),
                 dto.symptoms(),
                 dto.treatment(),
-                dto.prescription(),
+                dto.pickup(),
                 null // createdAt will be set by the service layer
         );
     }
@@ -29,7 +29,7 @@ public class ClinicHistoryMapper {
                 clinicHistory.getDiagnosis(),
                 clinicHistory.getSymptoms(),
                 clinicHistory.getTreatment(),
-                clinicHistory.getPrescription()
+                clinicHistory.getPickup()
         );
     }
 }

--- a/src/main/java/com/si516/saludconecta/service/impl/ClinicHistoryServiceImpl.java
+++ b/src/main/java/com/si516/saludconecta/service/impl/ClinicHistoryServiceImpl.java
@@ -1,7 +1,7 @@
 package com.si516.saludconecta.service.impl;
 
 import com.si516.saludconecta.document.ClinicHistory;
-import com.si516.saludconecta.document.Prescription;
+import com.si516.saludconecta.document.Pickup;
 import com.si516.saludconecta.document.Treatment;
 import com.si516.saludconecta.dto.ClinicHistoryDTO;
 import com.si516.saludconecta.event.TranscriptionCompletedEvent;
@@ -90,14 +90,14 @@ public class ClinicHistoryServiceImpl implements ClinicHistoryService {
             clinicHistory.setTreatment(List.of());
         }
 
-        // Mapear prescription con validación
-        Map<String, Object> prescriptionMap = (Map<String, Object>) extractedData.get("prescription");
-        if (prescriptionMap != null) {
-            Prescription prescription = objectMapper.convertValue(prescriptionMap, Prescription.class);
-            clinicHistory.setPrescription(prescription);
+        // Mapear recogida con validación
+        Map<String, Object> pickupMap = (Map<String, Object>) extractedData.get("pickup");
+        if (pickupMap != null) {
+            Pickup pickup = objectMapper.convertValue(pickupMap, Pickup.class);
+            clinicHistory.setPickup(pickup);
         } else {
-            // Crear prescription por defecto usando el enum correcto
-            clinicHistory.setPrescription(new Prescription(com.si516.saludconecta.enums.PickupType.LATER, null));
+            // Crear recogida por defecto usando el enum correcto
+            clinicHistory.setPickup(new Pickup(com.si516.saludconecta.enums.PickupType.LATER, null));
         }
 
         // Usar los IDs reales desde los metadatos del archivo


### PR DESCRIPTION
This pull request introduces changes to the `ClinicHistory` domain model and related components, replacing the `Prescription` class with a new `Pickup` class, removing the `officeId` field, and adding a `createdAt` field with proper formatting. These updates impact multiple files, including DTOs, mappers, and service implementations, to align with the updated schema.

### Domain Model Updates:
* Replaced the `Prescription` class with the `Pickup` class in the `ClinicHistory` model, along with its associated fields and references. The new `Pickup` class includes `pickupType` and `scheduledTime` attributes. (`src/main/java/com/si516/saludconecta/document/ClinicHistory.java` - [[1]](diffhunk://#diff-35cbb1174e3e9afca2f964341ed58e1215f7fc44de53c28a419ed8612f7edf85L20-R26) `src/main/java/com/si516/saludconecta/document/Pickup.java` - [[2]](diffhunk://#diff-3c2fd3ce9adab1fdf197becaed17f46ccd378497d12dced1dd5b667da4229fd3L11-R11)
* Removed the `officeId` field from the `ClinicHistory` model. (`src/main/java/com/si516/saludconecta/document/ClinicHistory.java` - [src/main/java/com/si516/saludconecta/document/ClinicHistory.javaL20-R26](diffhunk://#diff-35cbb1174e3e9afca2f964341ed58e1215f7fc44de53c28a419ed8612f7edf85L20-R26))

### DTO and Serialization Changes:
* Updated `ClinicHistoryDTO` to replace the `Prescription` field with `Pickup` and added a new `createdAt` field with a `JsonFormat` annotation for proper date-time formatting. Removed the `officeId` field. (`src/main/java/com/si516/saludconecta/dto/ClinicHistoryDTO.java` - [src/main/java/com/si516/saludconecta/dto/ClinicHistoryDTO.javaL3-R26](diffhunk://#diff-7a22e4138275744c382facb544f38ca59b643cccd17aed251c6fa0d9524d2b82L3-R26))

### Mapper Adjustments:
* Modified the `ClinicHistoryMapper` to map the new `Pickup` field and handle the removal of `officeId`. Added support for the new `createdAt` field in both `toEntity` and `toDTO` methods. (`src/main/java/com/si516/saludconecta/mapper/ClinicHistoryMapper.java` - [[1]](diffhunk://#diff-537f8ddb1b39a33919251d07d60e5b4cc3a0fc607c20d53e9aadd382f24de15cL11-R16) [[2]](diffhunk://#diff-537f8ddb1b39a33919251d07d60e5b4cc3a0fc607c20d53e9aadd382f24de15cL26-R31)

### Service Implementation Updates:
* Updated `ClinicHistoryServiceImpl` to handle the mapping and validation of the `Pickup` field instead of `Prescription`. Adjusted default value creation for the `Pickup` field. (`src/main/java/com/si516/saludconecta/service/impl/ClinicHistoryServiceImpl.java` - [src/main/java/com/si516/saludconecta/service/impl/ClinicHistoryServiceImpl.javaL93-R100](diffhunk://#diff-b298ac22b1119cee11a91ed51b5bf92d18e78c213a0f6744c12932ec8b34c064L93-R100))

### Related Issues
* Closes #23 