### PR TITLE
feat(config): add CORS configuration for frontend communication

### DIFF
--- a/src/main/java/com/si516/saludconecta/config/CorsConfig.java
+++ b/src/main/java/com/si516/saludconecta/config/CorsConfig.java
@@ -1,0 +1,21 @@
+package com.si516.saludconecta.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+    static final int MAX_CACHING_TIME_IN_SECONDS = 3600;
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry
+                .addMapping("/**")
+                .allowedOrigins("http://localhost:5173")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(MAX_CACHING_TIME_IN_SECONDS);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new `CorsConfig` class to configure Cross-Origin Resource Sharing (CORS) for the application. The configuration allows specific origins, methods, and headers, and sets caching parameters.

### New CORS Configuration:

* [`src/main/java/com/si516/saludconecta/config/CorsConfig.java`](diffhunk://#diff-0c391a7075f8b139a944aa3360f27ddc9ff82e42d54f9346c354d9f7f9eb54b1R1-R21): Added a new `CorsConfig` class implementing `WebMvcConfigurer`. This class configures CORS to allow requests from `http://localhost:5173`, supports common HTTP methods (`GET`, `POST`, `PUT`, `DELETE`, `OPTIONS`), allows all headers, enables credentials, and sets a max caching time of 3600 seconds.

### Related Issues:
* Closes #27 